### PR TITLE
Reset css

### DIFF
--- a/bin/build/dev/css.js
+++ b/bin/build/dev/css.js
@@ -11,8 +11,7 @@ const options = {
     --output-style expanded \
     --sourceComments true \
     -o ${outputDir}`,
-  sasslint: `-c ./sass-lint.yml \
-    ${sourceDir}/**/*.scss -v -q`
+  sasslint: `-c ./sass-lint.yml  -v -q`
 }
 
 const sassLintExec = shelljs.exec(`sass-lint ${options.sasslint}`);

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "npm-run-all": "^3.1.0",
     "onchange": "^3.0.2",
     "postcss-cli": "^2.6.0",
+    "reset-css": "^2.2.0",
     "sass-lint": "^1.9.1"
   }
 }

--- a/sass-lint.yml
+++ b/sass-lint.yml
@@ -1,6 +1,9 @@
 # File Options
 files:
-  include: 'src/sass/**/*.scss'
+  include:
+    - 'src/scss/*.scss'
+    - 'src/scss/**/*.scss'
+
 # Rule Configuration
 rules:
   no-transition-all: 0

--- a/src/scss/generic/_reset.scss
+++ b/src/scss/generic/_reset.scss
@@ -1,7 +1,1 @@
-// TODO: temp
-
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
+@import './node_modules/reset-css/_reset';

--- a/src/scss/ninja-gaiden.scss
+++ b/src/scss/ninja-gaiden.scss
@@ -1,8 +1,7 @@
-// TODO: temp
-@import "settings/colors";
-@import "tools/mixins/clearfix";
-@import "components/button";
-@import "generic/reset";
+@import 'settings/colors';
+@import 'generic/reset';
+@import 'tools/mixins/clearfix';
+@import 'components/button';
 
 body {
   font-size: 16px;

--- a/src/scss/tools/mixins/_clearfix.scss
+++ b/src/scss/tools/mixins/_clearfix.scss
@@ -3,7 +3,7 @@
 @mixin clearfix() {
   &::after,
   &::before {
-    content: "";
+    content: '';
     clear: both;
   }
 }


### PR DESCRIPTION
Adicionando o `CSS Reset` pelo NPM (https://www.npmjs.com/package/reset-css)
Também arrumando problemas com nosso `sass-lint` para incluir o arquivo do `ninja-gaiden.scss` na raiz da pasta `src/scss`.

