### PR TITLE
Using -moz-force-broken-image-icon

### DIFF
--- a/src/scss/components/_picture.scss
+++ b/src/scss/components/_picture.scss
@@ -55,6 +55,7 @@
     }
 
     .picture__image {
+      -moz-force-broken-image-icon: 1; //sass-lint:disable-line no-misspelled-properties
       margin: auto;
       position: absolute;
       top: -9999px;


### PR DESCRIPTION
**CHANGELOG** :memo:

* On Firefox, if a image is broken the alt text expands the img tag box layout. `-moz-force-broken-image-icon` disable this behaviour;