### PR TITLE
Updating sass-lint (to use disable feature)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "onchange": "^3.0.2",
     "postcss-cli": "^2.6.0",
     "reset-css": "^2.2.0",
-    "sass-lint": "git+ssh://git@github.com:sasstools/sass-lint#feature/disable-linters"
+    "sass-lint": "^1.10.2"
   }
 }


### PR DESCRIPTION
**CHANGELOG** :memo:

* Sass-lint now have a disable option (ex: `//sass-lint:disable no-protocol-url`).