### PR TITLE
Fixing flex direction on media__content element

### DIFF
--- a/src/scss/components/_media_box.scss
+++ b/src/scss/components/_media_box.scss
@@ -49,5 +49,6 @@
 
   &__content {
     @include flex-wrap(wrap);
+    @include flex-direction(column);
   }
 }


### PR DESCRIPTION
**CHANGELOG** :memo:

* Media component had a bug on title elements with many content.