### PR TITLE
Fixing word-break on media__content

### DIFF
--- a/src/scss/components/_media_box.scss
+++ b/src/scss/components/_media_box.scss
@@ -50,5 +50,6 @@
   &__content {
     @include flex-wrap(wrap);
     @include flex-direction(column);
+    word-break: break-all;
   }
 }


### PR DESCRIPTION
**CHANGELOG** :memo:

* Fix on media__content to break-all content