### PR TITLE
break-word instead break-all on media__content

### DIFF
--- a/src/scss/components/_media_box.scss
+++ b/src/scss/components/_media_box.scss
@@ -50,6 +50,6 @@
   &__content {
     @include flex-wrap(wrap);
     @include flex-direction(column);
-    word-break: break-all;
+    word-break: break-word;
   }
 }


### PR DESCRIPTION
**CHANGELOG** :memo:

* Ops. Using break-word, instead break-all.
