### PR TITLE
Removing debug option of documentjs

### DIFF
--- a/documentjs.json
+++ b/documentjs.json
@@ -1,7 +1,4 @@
 {
-  "siteDefaults": {
-    "debug": true
-  },
   "sites": {
     "gaiden_css": {
       "glob": "src/scss/**/*.{css,scss,md}",


### PR DESCRIPTION
**CHANGELOG** :memo:

* Removing debug of documentjs. This log are obfuscating other logs, like sass-lint (reference to #48 )