### PR TITLE
Dialog fix flexbox and renaming dialog elements

### DIFF
--- a/docs/demo/gaiden-css/components/dialog/demo.html
+++ b/docs/demo/gaiden-css/components/dialog/demo.html
@@ -9,35 +9,35 @@
   <link rel="stylesheet" href="/gaiden-css/base.css">
 </head>
 <body>
-  <section class="container wall wall--highlighted">
-    <div class="dialog col-small-12 col-normal-5">
-      <blockquote class="dialog__quote">
-        <p>Precisava fazer um telhado no meu quintal, entrei no GetNinjas e fiz um pedido de pedreiro, eles entraram em contato comigo no mesmo dia, escolhi o que melhor me atendeu e fechei o serviço.</p>
-      </blockquote>
-
-      <dl class="dialog__user space-box-medium">
-        <dd class="dialog__user__photo picture picture--rounded">
-          <img src="http://placehold.it/40x40" alt="" class="picture__image" height="40" width="40">
-        </dd>
-        <div class="wrap__dialog__itens">
-          <dt class="dialog__user__name">Silvia D.</dt>
-          <dd class="dialog__user__location">São Paulo - SP</dd>
-        </div>
-      </dl>
-    </div>
-
+  <section class="container wall wall--highlighted content-centered col-centered">
     <div class="dialog col-small-12 col-normal-5 space-box-large">
       <blockquote class="dialog__quote">
         <p>Precisava fazer um telhado no meu quintal, entrei no GetNinjas e fiz um pedido de pedreiro, eles entraram em contato comigo no mesmo dia, escolhi o que melhor me atendeu e fechei o serviço.</p>
       </blockquote>
 
       <dl class="dialog__user space-box-medium">
-        <dd class="dialog__user__photo picture picture--rounded">
+        <dd class="dialog__user-photo picture picture--rounded">
           <img src="http://placehold.it/40x40" alt="" class="picture__image" height="40" width="40">
         </dd>
-        <div class="wrap__dialog__itens">
-          <dt class="dialog__user__name">Silvia D.</dt>
-          <dd class="dialog__user__location">São Paulo - SP</dd>
+        <div class="wrap__dialog-itens">
+          <dt class="dialog__user-name">Silvia D.</dt>
+          <dd class="dialog__user-location">São Paulo - SP</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div class="dialog col-small-12 col-normal-5 space-box-large">
+      <blockquote class="dialog__quote">
+        <p>Precisava fazer um telhado no meu quintal.</p>
+      </blockquote>
+
+      <dl class="dialog__user space-box-medium">
+        <dd class="dialog__user-photo picture picture--rounded">
+          <img src="http://placehold.it/40x40" alt="" class="picture__image" height="40" width="40">
+        </dd>
+        <div class="wrap__dialog-itens">
+          <dt class="dialog__user-name">Silvia D.</dt>
+          <dd class="dialog__user-location">São Paulo - SP</dd>
         </div>
       </dl>
     </div>

--- a/docs/demo/gaiden-css/components/dialog/demo.html
+++ b/docs/demo/gaiden-css/components/dialog/demo.html
@@ -15,15 +15,15 @@
         <p>Precisava fazer um telhado no meu quintal, entrei no GetNinjas e fiz um pedido de pedreiro, eles entraram em contato comigo no mesmo dia, escolhi o que melhor me atendeu e fechei o serviço.</p>
       </blockquote>
 
-      <dl class="dialog__user space-box-medium">
-        <dd class="dialog__user-photo picture picture--rounded">
-          <img src="http://placehold.it/40x40" alt="" class="picture__image" height="40" width="40">
-        </dd>
+      <div class="dialog__user space-box-medium">
+        <picture class="dialog__user-photo picture picture--rounded">
+          <img src="http://placehold.it/40x40" alt="Avatar for Silvia D." class="picture__image" height="40" width="40">
+        </picture>
         <div class="wrap__dialog-itens">
-          <dt class="dialog__user-name">Silvia D.</dt>
-          <dd class="dialog__user-location">São Paulo - SP</dd>
+          <div class="dialog__user-name">Silvia D.</div>
+          <div class="dialog__user-location">São Paulo - SP</div>
         </div>
-      </dl>
+      </div>
     </div>
 
     <div class="dialog col-small-12 col-normal-5 space-box-large">
@@ -31,15 +31,16 @@
         <p>Precisava fazer um telhado no meu quintal.</p>
       </blockquote>
 
-      <dl class="dialog__user space-box-medium">
-        <dd class="dialog__user-photo picture picture--rounded">
-          <img src="http://placehold.it/40x40" alt="" class="picture__image" height="40" width="40">
-        </dd>
+      <div class="dialog__user space-box-medium">
+        <picture class="dialog__user-photo picture picture--rounded">
+          <img src="http://placehold.it/40x40" alt="Avatar for Silvia D." class="picture__image" height="40" width="40">
+        </picture>
         <div class="wrap__dialog-itens">
-          <dt class="dialog__user-name">Silvia D.</dt>
-          <dd class="dialog__user-location">São Paulo - SP</dd>
+          <div class="dialog__user-name">Silvia D.</div>
+          <div class="dialog__user-location">São Paulo - SP</div>
         </div>
-      </dl>
+      </div>
+    </div>
     </div>
   </section>
 </body>

--- a/src/scss/components/_dialog.scss
+++ b/src/scss/components/_dialog.scss
@@ -7,14 +7,19 @@
 **/
 
 .dialog {
+  @include flex-direction(column);
   justify-content: center;
   font-size: 14px;
 
   &__quote {
+    @include flexbox;
+    @include flex;
     padding: 30px;
     position: relative;
     background-color: get-color(air);
     border-radius: 10px;
+    align-items: center;
+    justify-content: center;
     font-style: italic;
 
     &::after {
@@ -31,8 +36,9 @@
   }
 
   &__user {
-    display: flex;
+    @include flexbox;
     text-align: left;
+    justify-content: center;
 
     &__photo {
       margin-right: 10px;

--- a/src/scss/components/_dialog.scss
+++ b/src/scss/components/_dialog.scss
@@ -40,17 +40,17 @@
     text-align: left;
     justify-content: center;
 
-    &__photo {
+    &-photo {
       margin-right: 10px;
     }
 
-    &__name {
+    &-name {
       line-height: 15px;
       font-weight: bold;
       padding-top: 4px;
     }
 
-    &__location {
+    &-location {
       font-size: 12px;
       line-height: 15px;
     }

--- a/src/scss/components/_dialog.scss
+++ b/src/scss/components/_dialog.scss
@@ -32,6 +32,7 @@
 
   &__user {
     display: flex;
+    text-align: left;
 
     &__photo {
       margin-right: 10px;

--- a/src/scss/components/_dialog.scss
+++ b/src/scss/components/_dialog.scss
@@ -5,12 +5,13 @@
   * ## Services
   * @demo demo/gaiden-css/components/dialog/demo.html
 **/
+
 .dialog {
   justify-content: center;
   font-size: 14px;
 
   &__quote {
-    padding: 44px 20px;
+    padding: 30px;
     position: relative;
     background-color: get-color(air);
     border-radius: 10px;


### PR DESCRIPTION
**CHANGELOG** :memo:

* Fixing flexbox issues on dialog component;
* Renaming the `dialog__user` elements;

**PRINTS** 🖼 

The height of dialog elements are equal now.

![screen shot 2016-12-05 at 8 57 45 pm](https://cloud.githubusercontent.com/assets/1279783/20906071/86b4cc90-bb2d-11e6-948c-b3a53722cece.png)

❗️  **BREAK CHANGE** ❗️ 

About the renaming of `dialog__user` elements. Now, we are calling `dialog__user` nested childrens by `dialog__user-name`, `dialog__user-location` instead `dialog__user__name`, `dialog__user__location`. This way is more BEM style than before. The concept of element of element don't exists on BEM methodology.
