### PR TITLE
Removing inherit value from footer disclaimer

### DIFF
--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -8,9 +8,6 @@
 .footer {
   @include flexbox;
   @include flex-direction(column);
-  @include media(small) {
-    text-align: inherit;
-  }
   @include media(medium) {
     max-height: map-deep-get($footerSize, mini, size) + px;
   }


### PR DESCRIPTION
**CHANGELOG** :memo:

* Footer disclaimer was assuming a text-align left from another parent element.