### PR TITLE
removed inverted scale

### DIFF
--- a/src/scss/components/_thumbnail.scss
+++ b/src/scss/components/_thumbnail.scss
@@ -34,6 +34,8 @@
     }
 
     .thumbnail__photo {
+      transform: scale(-1);
+
       img {
         width: 100%;
         height: auto;
@@ -59,7 +61,6 @@
     width: 100%;
     border-radius: $borderRadius;
     display: block;
-    transform: scale(-1);
 
     img {
       width: auto;


### PR DESCRIPTION
**CHANGELOG** :memo:

* Fixing inverted thumbnail__photo
* Problem description:
After a crossbrowser refactor on the thumbnail--action component, the thumbnail__photo element was affected because both inherit the same class (thumbnail__photo).
* Solution:
Moved the change from thumbnail__photo  to thumbnail--action scope

![captura de tela 2017-04-03 as 9 27 13 am](https://cloud.githubusercontent.com/assets/178548/24609213/56a563b8-1850-11e7-9bdd-7b8de65108da.png)
