### PR TITLE
Fixing visual equivalent h5 class

### DIFF
--- a/docs/demo/gaiden-css/generic/headings/demo.html
+++ b/docs/demo/gaiden-css/generic/headings/demo.html
@@ -16,30 +16,30 @@
 </head>
 
 <body>
-    <h1 class="" arial-level="1" role="heading">
-      H1 Title Gaiden
-      <small>Sub Title Gaiden</small>
-    </h1><br>
-    <h2 class="" arial-level="1" role="heading">
-      H2 Title Gaiden
-      <small>Sub Title Gaiden</small>
-    </h2><br>
-    <h3 class="" arial-level="1" role="heading">
-      H3 Title Gaiden
-      <small>Sub Title Gaiden</small>
-    </h3><br>
-    <h4 class="" arial-level="1" role="heading">
-      H4 Title Gaiden
-      <small>Sub Title Gaiden</small>
-    </h4><br>
-    <h5 class="" arial-level="1" role="heading">
-      H5 Title Gaiden
-      <small>Sub Title Gaiden</small>
-    </h5><br>
-    <h6 class="" arial-level="1" role="heading">
-      H6 Title Gaiden
-      <small>Sub Title Gaiden</small>
-    </h6>
+  <h1 class="" arial-level="1" role="heading">
+    H1 - Page Title
+    <small>Sub Title</small>
+  </h1><br>
+  <h2 class="" arial-level="1" role="heading">
+    H2 Section Title
+    <small>Sub Title</small>
+  </h2><br>
+  <h3 class="" arial-level="1" role="heading">
+    H3 Container Title
+    <small>Sub Title</small>
+  </h3><br>
+  <h4 class="" arial-level="1" role="heading">
+    H4 Card Title
+    <small>Sub Title</small>
+  </h4><br>
+  <h5 class="" arial-level="1" role="heading">
+    H5 Info Title
+    <small>Sub Title</small>
+  </h5><br>
+  <h6 class="" arial-level="1" role="heading">
+    H6 Caption Title
+    <small>Sub Title</small>
+  </h6>
 </body>
 
 </html>

--- a/docs/demo/gaiden-css/generic/headings/with-class/demo.html
+++ b/docs/demo/gaiden-css/generic/headings/with-class/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="maximum-scale=1,width=device-width,initial-scale=1,user-scalable=0">
+    <link rel="stylesheet" href="/gaiden-css/gaiden.css">
+    <link rel="stylesheet" href="/gaiden-css/base.css">
+    <style>
+      nav {
+        padding: 20px;
+      }
+
+    </style>
+    <title>Headings</title>
+  </head>
+
+  <body>
+    <h2 class="page-title" arial-level="2" role="heading">
+      Page Title (on h2)
+    </h2><br>
+    <h1 class="section-title" arial-level="1" role="heading">
+      Section Title (on h1)
+    </h1><br>
+    <h1 class="container-title" arial-level="1" role="heading">
+      Container Title (on h1)
+    </h1><br>
+    <h1 class="card-title" arial-level="1" role="heading">
+      Card Title (on h1)
+    </h1><br>
+    <h1 class="info-title" arial-level="1" role="heading">
+      H5 Info Title
+    </h1><br>
+    <h1 class="caption-title" arial-level="1" role="heading">
+      H6 Caption Title
+    </h1>
+  </body>
+</html>

--- a/src/scss/generic/_heading.scss
+++ b/src/scss/generic/_heading.scss
@@ -119,7 +119,7 @@ h4,
 }
 
 h5,
-.card-title {
+.info-title {
   font: {
     weight: get-weight(bold);
     size: 14px;

--- a/src/scss/generic/_heading.scss
+++ b/src/scss/generic/_heading.scss
@@ -1,7 +1,13 @@
 /**
   * @parent gaiden_css.generic
   * @stylesheet gaiden_css.generic.headings.css Headings
+  *
+  * ## Tags and subtitle (small)
+  * We are using heading tags with small to simulate a description of a heading element.
   * @demo demo/gaiden-css/generic/headings/demo.html
+  *
+  * ## Using classes
+  * @demo demo/gaiden-css/generic/headings/with-class/demo.html
 **/
 h1,
 h2,


### PR DESCRIPTION
**CHANGELOG** :memo:

* Just a minor fix to h5 heading element. The visual class equivalent is info-title, not card-title.