### PR TITLE
removing padding-bottom from incorrect scope

### DIFF
--- a/src/scss/components/_card.scss
+++ b/src/scss/components/_card.scss
@@ -40,7 +40,6 @@
 
   &--action {
     cursor: pointer;
-    padding-bottom: calc(44px + 16px);
     position: relative;
 
     &:hover {


### PR DESCRIPTION
**CHANGELOG** :memo:

* Removing padding-bottom from card--action scope

### Current
![screenshot capture - 2017-05-21 - 13-43-56](https://cloud.githubusercontent.com/assets/178548/26285736/b07f143c-3e2b-11e7-876f-5f84ff3d4976.png)

### Correct
![screenshot capture - 2017-05-21 - 13-44-14](https://cloud.githubusercontent.com/assets/178548/26285738/bf7308ea-3e2b-11e7-9fc2-4065b9f2573f.png)
