### PR TITLE
removing unnecessary class from demos

### DIFF
--- a/docs/demo/gaiden-css/components/thumbnail/action/demo.html
+++ b/docs/demo/gaiden-css/components/thumbnail/action/demo.html
@@ -12,7 +12,7 @@
   <section class="container">
     <a class="col-small-6 col-medium-6 col-normal-4 col-large-3 space-box-medium" href="#link">
       <div class="thumbnail thumbnail--action">
-          <div class="thumbnail__button info-title">
+          <div class="thumbnail__button">
             Chuveiro
           </div>
           <div class="thumbnail__photo picture">
@@ -22,18 +22,7 @@
     </a>
     <a class="col-small-6 col-medium-6 col-normal-4 col-large-3 space-box-medium" href="#link">
       <div class="thumbnail thumbnail--action">
-          <div class="thumbnail__button info-title">
-            Chuveiro
-          </div>
-          <div class="thumbnail__photo picture">
-            <img class="picture__image" src="/docs/demo/gaiden-css/images/services/thumbnail__photo.png" alt="Exemple image">
-          </div>
-      </div>
-    </a>
-
-    <a class="col-small-6 col-medium-6 col-normal-4 col-large-3 space-box-medium" href="#link">
-      <div class="thumbnail thumbnail--action">
-          <div class="thumbnail__button info-title">
+          <div class="thumbnail__button">
             Chuveiro
           </div>
           <div class="thumbnail__photo picture">
@@ -44,7 +33,7 @@
 
     <a class="col-small-6 col-medium-6 col-normal-4 col-large-3 space-box-medium" href="#link">
       <div class="thumbnail thumbnail--action">
-          <div class="thumbnail__button info-title">
+          <div class="thumbnail__button">
             Chuveiro
           </div>
           <div class="thumbnail__photo picture">
@@ -55,7 +44,18 @@
 
     <a class="col-small-6 col-medium-6 col-normal-4 col-large-3 space-box-medium" href="#link">
       <div class="thumbnail thumbnail--action">
-          <div class="thumbnail__button info-title">
+          <div class="thumbnail__button">
+            Chuveiro
+          </div>
+          <div class="thumbnail__photo picture">
+            <img class="picture__image" src="/docs/demo/gaiden-css/images/services/thumbnail__photo.png" alt="Exemple image">
+          </div>
+      </div>
+    </a>
+
+    <a class="col-small-6 col-medium-6 col-normal-4 col-large-3 space-box-medium" href="#link">
+      <div class="thumbnail thumbnail--action">
+          <div class="thumbnail__button">
             Chuveiro
           </div>
           <div class="thumbnail__photo picture">


### PR DESCRIPTION
**CHANGELOG** :memo:

* Removing unnecessary class from Thumbnail demos, causing the caption to be too big

### Current
![screenshot capture - 2017-05-21 - 13-56-18](https://cloud.githubusercontent.com/assets/178548/26285811/863dced2-3e2d-11e7-8e18-fc140093322f.png)

### Correct
![screenshot capture - 2017-05-21 - 13-57-57](https://cloud.githubusercontent.com/assets/178548/26285812/89cbb820-3e2d-11e7-8c0a-35cb05cb8b2b.png)
