### PR TITLE
Add word-wrap to media-box__body

### DIFF
--- a/src/scss/components/_media_box.scss
+++ b/src/scss/components/_media_box.scss
@@ -85,6 +85,7 @@
     color: get-color((color: blackNeutral, key: darker, opacity: .6));
     font-size: 14px;
     font-style: italic;
+    word-wrap: break-word;
   }
 
   &__content {


### PR DESCRIPTION
**CHANGELOG**  :memo:

* Issue: #112 
* Add `break-word` to `word-wrap` property on `.media-box__body`.

**Current**
![captura de tela 2017-06-06 as 11 37 54](https://cloud.githubusercontent.com/assets/6332116/26834801/c13bcbe8-4aac-11e7-8ca3-827cfe8efb13.png)

**Correct**
![captura de tela 2017-06-06 as 11 38 21](https://cloud.githubusercontent.com/assets/6332116/26834816/cdb2db6e-4aac-11e7-9084-6668dfa8c3f9.png)
