### PR TITLE
fixed title width IE10

### DIFF
--- a/src/scss/components/_media_box.scss
+++ b/src/scss/components/_media_box.scss
@@ -44,6 +44,7 @@
   &__title {
     color: inherit;
     font-size: 14px;
+    width: 100%;
 
     .card__title {
       color: get-color((color: blackNeutral, key: darker, opacity: .6));


### PR DESCRIPTION
#118 **CHANGELOG** :memo:

* Adding width to the media box title to fix the display on IE10

![dashboard](https://user-images.githubusercontent.com/178548/27764511-cde048b4-5e71-11e7-9e2e-90c97cb804f9.png)

## Safari
![captura de tela 2017-07-03 as 3 18 52 pm](https://user-images.githubusercontent.com/178548/27804005-fd1d9b44-6002-11e7-9b1f-520dc974d3d3.png)

## Chrome
![captura de tela 2017-07-03 as 3 17 44 pm](https://user-images.githubusercontent.com/178548/27804010-04561300-6003-11e7-8f57-f8f6eba13f94.png)

## FF
![captura de tela 2017-07-03 as 3 17 19 pm](https://user-images.githubusercontent.com/178548/27804016-0c265522-6003-11e7-95a7-c5498a6f56a4.png)

## Edge
![captura de tela 2017-07-03 as 3 23 04 pm](https://user-images.githubusercontent.com/178548/27804106-8f335000-6003-11e7-842c-ed4f540866cf.png)

## IE 11
![captura de tela 2017-07-03 as 3 25 42 pm](https://user-images.githubusercontent.com/178548/27804185-ed0fb38a-6003-11e7-85e6-ed09e5a73a2c.png)


