### PR TITLE
Moving import of resetcss outside of generic folder

### DIFF
--- a/src/scss/gaiden.scss
+++ b/src/scss/gaiden.scss
@@ -1,3 +1,4 @@
+@import 'node_modules/reset-css/_reset'; //sass-lint:disable-line clean-import-paths
 @import 'settings/colors';
 @import 'settings/grid';
 @import 'settings/buttons';

--- a/src/scss/generic/_reset.scss
+++ b/src/scss/generic/_reset.scss
@@ -1,5 +1,4 @@
 //sass-lint:disable-all
-@import './node_modules/reset-css/_reset';
 
 * {
   box-sizing: border-box;


### PR DESCRIPTION
**CHANGELOG** :memo:

* Import of reset-css was inside of `generic / _reset.scss`. When we had to import independent files, instead `gaiden.scss`, this dependency of reset-css was implicit.
* Now, projects that are using just of some of components need to import reset-css on their environment to Gaiden works fine.