### PR TITLE
Fixing routes to static assets on docs

### DIFF
--- a/.browser-sync-docs.js
+++ b/.browser-sync-docs.js
@@ -17,9 +17,19 @@ module.exports = {
   files: "/docs",
   server: {
     baseDir: "docs",
-    directory: true
+    directory: true,
+    routes: {
+      "/gaiden.css": "./docs/gaiden-css/gaiden.css",
+      "/base.css": "./docs/gaiden-css/base.css",
+      "/docs/demo/gaiden-css/images/star-full.svg": "./docs/demo/gaiden-css/images/star-full.svg"
+    }
   },
   port: 8000,
   open: false,
-  cors: true
+  cors: true,
+  //middleware: function (req, res, next) {
+    //console.log(req);
+
+    //return next();
+  //},
 };

--- a/.browser-sync-docs.js
+++ b/.browser-sync-docs.js
@@ -26,10 +26,5 @@ module.exports = {
   },
   port: 8000,
   open: false,
-  cors: true,
-  //middleware: function (req, res, next) {
-    //console.log(req);
-
-    //return next();
-  //},
+  cors: true
 };


### PR DESCRIPTION
**CHANGELOG** :memo:

* Using `routes` options from browsersync fix some errors on dev documentation pages