### PR TITLE
Bugfix/overflow on picture rounded

### DIFF
--- a/src/scss/components/_media_box.scss
+++ b/src/scss/components/_media_box.scss
@@ -65,6 +65,7 @@
 
   &__picture {
     margin-right: 10px;
+    max-height: 38px;
     min-width: 38px;
   }
 

--- a/src/scss/components/_media_box.scss
+++ b/src/scss/components/_media_box.scss
@@ -65,7 +65,6 @@
 
   &__picture {
     margin-right: 10px;
-    max-height: 38px;
     min-width: 38px;
   }
 

--- a/src/scss/components/_picture.scss
+++ b/src/scss/components/_picture.scss
@@ -37,7 +37,9 @@
     overflow: hidden;
 
     .picture__image {
+      background-color: get-color(recusaGray);
       border-radius: 50%;
+      overflow: hidden;
     }
   }
 

--- a/src/scss/components/_picture.scss
+++ b/src/scss/components/_picture.scss
@@ -34,9 +34,10 @@
   }
 
   &--rounded {
+    overflow: hidden;
+
     .picture__image {
       border-radius: 50%;
-      overflow: hidden;
     }
   }
 

--- a/src/scss/components/_picture.scss
+++ b/src/scss/components/_picture.scss
@@ -36,6 +36,7 @@
   &--rounded {
     .picture__image {
       border-radius: 50%;
+      overflow: hidden;
     }
   }
 


### PR DESCRIPTION
**CHANGELOG** :memo:

* When picture is broken, alt text makes height expand absurdly (print image below);
* The solution is to use a height and overflow hidden on picture_image. If we need to avoid alt text broken the image, we need to define height of this images on CSS of specific project.

**Before:**
![screen shot 2017-09-18 at 02 07 00](https://user-images.githubusercontent.com/1279783/30529668-19e6d53e-9c16-11e7-9c84-790b1874343b.png)

**After (with height defined on project, not Gaiden):**
![screen shot 2017-09-18 at 02 34 43](https://user-images.githubusercontent.com/1279783/30530068-f70a58b6-9c19-11e7-8341-5429d9df353f.png)
