### PR TITLE
When container and list are together, there is no padding

### DIFF
--- a/docs/demo/gaiden-css/components/list/stacked/using_grid_system/demo.html
+++ b/docs/demo/gaiden-css/components/list/stacked/using_grid_system/demo.html
@@ -14,8 +14,8 @@
 
 <body>
   <article>
-    <header>
-      <h5>Topic List Header</h5>
+    <header class="container">
+      <h5 class="col-small-12">Topic List Header</h5>
     </header>
     <div class="container">
       <nav class="col-small-7">

--- a/docs/demo/gaiden-css/components/list/using_grid_system/demo.html
+++ b/docs/demo/gaiden-css/components/list/using_grid_system/demo.html
@@ -13,11 +13,11 @@
 </head>
 
 <body>
-  <article>
-    <header>
-      <h5>Topic List Header</h5>
+  <article class="container">
+    <header class="container">
+      <h5 class="col-small-12">Topic List Header</h5>
     </header>
-    <nav>
+    <nav class="col-small-12">
       <ul class="list list--link">
         <li class="list__item col-small-12 col-medium-6">
           <a href="javascript:void(0)">Pedreiro em Campinas 1</a>

--- a/src/scss/components/_list.scss
+++ b/src/scss/components/_list.scss
@@ -27,6 +27,13 @@
     @include clearfix;
   }
 
+  &.container {
+    padding: {
+      left: 0;
+      right: 0;
+    }
+  }
+
   &--link {
     color: get-color(punch);
     transition: transform ease-in-out .2s, background-color ease-in-out .3s;


### PR DESCRIPTION
**CHANGELOG** :memo:

* Lists don't need a padding when `container` is on the same element that `list` are in