### PR TITLE
Removing 0 margin-bottom from footer element

### DIFF
--- a/src/scss/components/_footer.scss
+++ b/src/scss/components/_footer.scss
@@ -42,7 +42,7 @@
       weight: get-weight(normal);
     };
     letter-spacing: .3px;
-    margin: 15px auto 0;
+    margin: 15px auto;
     padding: {
       left: 20px;
       right: 20px;


### PR DESCRIPTION
**CHANGELOG** :memo:

* Without margin-bottom, the calc of footer max-height it was wrong