### PR TITLE
Add widget align top modifier

### DIFF
--- a/src/scss/components/_widget.scss
+++ b/src/scss/components/_widget.scss
@@ -17,6 +17,10 @@
     margin-top: -180px;
   }
 
+  &--align-top {
+    align-self: flex-start;
+  }
+
   &__title {
     @include media(small) {
       font-size: 24px;

--- a/src/scss/components/_widget.scss
+++ b/src/scss/components/_widget.scss
@@ -17,7 +17,7 @@
     margin-top: -180px;
   }
 
-  &--align-top {
+  &--no-vertical-grow {
     align-self: flex-start;
   }
 


### PR DESCRIPTION
**CHANGELOG** :memo:

* This is a propose for `widget` class, adding a `--align-top` top modifier that solve the flex problem in some cases that we want to height between elements to different.

Before:
![image](https://user-images.githubusercontent.com/6332116/34787641-20ec10b6-f61f-11e7-88b7-ce94796ba49d.png)

After:
![image](https://user-images.githubusercontent.com/6332116/34787777-a0494202-f61f-11e7-9240-2a99dfd6ab67.png)


