### PR TITLE
Fix z-index label when parent inputs radio and checkbox.

### DIFF
--- a/src/scss/components/form/_checkbox.scss
+++ b/src/scss/components/form/_checkbox.scss
@@ -58,6 +58,7 @@
     color: get-color((color: blackNeutral, opacity: .6));
     font-size: 14px;
     margin-left: 11px;
+    z-index: 2;
 
     &::before {
       background-color: get-color(breeze);

--- a/src/scss/components/form/_radio.scss
+++ b/src/scss/components/form/_radio.scss
@@ -59,6 +59,7 @@
     color: get-color((color: blackNeutral, opacity: .6));
     font-size: 14px;
     margin-left: 11px;
+    z-index: 2;
 
     &::before {
       background-color: get-color(breeze);


### PR DESCRIPTION
**CHANGELOG** :memo:

* To fix a test capybara on scorpion project I had include `z-index` to click on the label.
