### PR TITLE
Add card--fluid that enforces 100% of width

### DIFF
--- a/src/scss/components/_card.scss
+++ b/src/scss/components/_card.scss
@@ -116,4 +116,8 @@
   .no-flexbox & {
     width: 100%;
   }
+
+  &--fluid {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
**CHANGELOG** :memo:

* Add fluid modifier to `.card` component that enforces 100% of width. This is already documented, but don't exists.
