### PR TITLE
Fix break card profile

### DIFF
--- a/src/scss/components/_card-profile.scss
+++ b/src/scss/components/_card-profile.scss
@@ -62,4 +62,10 @@
     padding: 12px;
     width: 100%;
   }
+
+  &.card--action {
+    .card-profile__highlight {
+      padding-bottom: 57px;
+    }
+  }
 }


### PR DESCRIPTION
## CHANGELOG :memo:

* Fix break card profile when have class modifier `card--action`.

## PRINTS

### Before
![screen shot 2018-02-20 at 22 17 49](https://user-images.githubusercontent.com/6557202/36458131-198e9446-168c-11e8-9f63-a8409fd6d174.png)

### After
![screen shot 2018-02-20 at 22 18 00](https://user-images.githubusercontent.com/6557202/36458137-20f0e856-168c-11e8-850f-5b33ac4ea008.png)

