### PR TITLE
Adjustments card profile and shadow size

### DIFF
--- a/src/scss/components/_card-profile.scss
+++ b/src/scss/components/_card-profile.scss
@@ -47,7 +47,7 @@
   }
 
   &__highlight {
-    background-color: get-color(wall);
+    background-color: get-color(offWhite);
     min-height: 108px;
     padding: 16px 24px;
   }

--- a/src/scss/settings/_buttons.scss
+++ b/src/scss/settings/_buttons.scss
@@ -184,7 +184,7 @@ $buttonTypes: (
     default: (
       background: punch,
       textColor: air,
-      shadow: ( kind: large  )
+      shadow: ( kind: normal )
     ),
     hover: (
       background: serious
@@ -202,7 +202,7 @@ $buttonTypes: (
   raised-reversed: (
     default: (
       background: air,
-      shadow: ( kind: large  ),
+      shadow: ( kind: normal ),
       textColor: punch
     ),
     hover: (

--- a/src/scss/settings/_shadows.scss
+++ b/src/scss/settings/_shadows.scss
@@ -5,7 +5,7 @@
 *  @body
 *    ## Using
 *      $shadows: (
-*        normal: 0 1px 1px 0,
+*        normal: 0 1px 2px 0,
 *        medium: 0 2px 4px 0,
 *        large: 0 4px 8px 0,
 *        none: 0 0 0 0
@@ -13,7 +13,7 @@
 **/
 
 $shadows: (
-  normal: 0 1px 1px 0,
+  normal: 0 1px 2px 0,
   medium: 0 2px 4px 0,
   large: 0 4px 8px 0,
   none: 0 0 0 0


### PR DESCRIPTION
**CHANGELOG** :memo:

* Change the `background-color` for the highlight text in card profile.
* Change the normal size shadow.
* Change shadow in button large to normal.

**PRINTS**

Card Profile - Before
![screen shot 2018-03-02 at 16 41 03](https://user-images.githubusercontent.com/6557202/36973484-fbc18e62-2051-11e8-93db-f01c6d95402c.png)

Card Profile - After
![screen shot 2018-03-05 at 08 49 43](https://user-images.githubusercontent.com/6557202/36973547-3ad56be6-2052-11e8-89ed-f9f4f1480c23.png)

Button - Shadow - Before
![screen shot 2018-03-05 at 08 52 05](https://user-images.githubusercontent.com/6557202/36973665-9d6a9d3a-2052-11e8-8325-c8c6aa20367d.png)

Button - Shadow - After
![screen shot 2018-03-05 at 09 34 56](https://user-images.githubusercontent.com/6557202/36975328-82da91e0-2058-11e8-8e7a-bcb928318177.png)


