### PR TITLE
Fix transition property

### DIFF
--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -99,9 +99,7 @@
   line-height: 1;
   text-align: center;
   text-transform: uppercase;
-  transition-duration: .2s, .2s, .2s, .3s;
-  transition-property: border-color, box-shadow, background-color, color;
-  transition-timing-function: ease-in, ease-in, ease-in, ease;
+  transition: border-color .2s ease-in, box-shadow .2s ease-in, background-color .2s ease-in, color .3s ease;
 
   &[disabled] {
     cursor: not-allowed;

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -119,9 +119,7 @@
     font-style: italic;
     line-height: 1.3;
     padding: 11px;
-    transition-duration: .15s;
-    transition-property: border-color, background-color;
-    transition-timing-function: ease-in;
+    transition: border-color .15s ease-in, background-color .15s ease-in;
 
     .form__field--fluid & {
       width: 100%;

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -29,8 +29,7 @@
       font-size: 14px;
       font-weight: get-weight(bold);
       padding: 4px 9px;
-      transition-duration: .2s, .2s, .2s;
-      transition-property: background-color, color, border-color;
+      transition: background-color .2s, color .2s, border-color .2s;
       width: 100%;
     }
 


### PR DESCRIPTION
**CHANGELOG** :memo:

* To fix some `warnings` in projects that use gaiden and `autoprefixer` it's need to change declaration of `transition`.

* The solution was found here:
[postcss/autoprefixer](https://github.com/postcss/autoprefixer/issues/617)

**After**

```
transition-duration: .15s;
transition-property: border-color, background-color;
transition-timing-function: ease-in;
```

**Before**

```
transition: border-color .15s ease-in, background-color .15s ease-in;
```