### PR TITLE
Change de space between item pagination

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,6 @@
 module.exports = {
   extends: [
-    'airbnb-base',
-    './common.js'
+    'airbnb-base'
   ],
 
   parser: 'babel-eslint',

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -12,12 +12,15 @@
 **/
 
 .pagination {
+  font-size: 0;
+
   &__item {
     cursor: pointer;
     display: inline-block;
+    font-size: initial;
 
     & + & {
-      margin-left: 2px;
+      margin-left: 6px;
     }
 
     a {

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -39,6 +39,7 @@
     &-jump {
       border: 0;
       display: inline-block;
+      font-size: initial;
       padding: 6px 5px;
     }
 


### PR DESCRIPTION
**DESCRIPTION**

Like the minify of HTML we lose the spacing of the property display: inline-block that we take into account in the pagination with this leaving the items more glued.

**CHANGELOG** :memo:

* Add `font-size: 0` to `.pagination` (Hack).
* Increment `margin-left` to `6px`.

**PRINT**

- As it was in our gaiden
![gaiden-right](https://user-images.githubusercontent.com/6557202/38419933-97c50084-3978-11e8-880e-a65020938716.png)

- how is it on our site, when we have HTML minification
![page-pagination-wrong](https://user-images.githubusercontent.com/6557202/38420220-6e7eefb8-3979-11e8-8d64-f2b453c07c6c.png)

- after the bugfix even with the mined HTML we will have the same result as we expected before
![screen shot 2018-04-06 at 09 31 02](https://user-images.githubusercontent.com/6557202/38421369-45efbbbe-397d-11e8-9868-b386b909b442.png)




