### PR TITLE
Fix list li click size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gaiden",
-  "version": "17.2.0",
+  "version": "17.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gaiden",
-  "version": "17.1.5",
+  "version": "17.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gaiden",
-  "version": "17.1.6",
+  "version": "17.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaiden",
-  "version": "17.2.0",
+  "version": "17.2.1",
   "description": "Styleguide for GetNinjas projects",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaiden",
-  "version": "17.1.5",
+  "version": "17.1.6",
   "description": "Styleguide for GetNinjas projects",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaiden",
-  "version": "17.1.6",
+  "version": "17.2.0",
   "description": "Styleguide for GetNinjas projects",
   "main": "index.js",
   "scripts": {

--- a/src/scss/components/_list.scss
+++ b/src/scss/components/_list.scss
@@ -179,6 +179,7 @@
 
         a {
           transform: translateX(8px);
+          width: 100%;
         }
       }
     }


### PR DESCRIPTION
**CHANGELOG** :memo:

- It fixes a use case we have that forces to click on the text to go.

:framed_picture: 

![image](https://user-images.githubusercontent.com/13206817/61057445-b745bc00-a3cb-11e9-9ca4-1fce22c2d36d.png)
 

SOLUTION

- Set full width on anchor tag to expand the clickable area.

:framed_picture: 

![image](https://user-images.githubusercontent.com/13206817/61057687-2de2b980-a3cc-11e9-8ac7-7ff5cd5a327a.png)
