### PR TITLE
Add word-wrap in content card profile

### DIFF
--- a/src/yellow/components/_card-profile.scss
+++ b/src/yellow/components/_card-profile.scss
@@ -70,6 +70,7 @@
   &__content {
     padding: $size-spacing-xs $size-spacing-s;
     width: 100%;
+    word-wrap: break-word;
   }
 
   &__text {

--- a/src/yellow/components/_card-profile.scss
+++ b/src/yellow/components/_card-profile.scss
@@ -42,10 +42,6 @@
     box-shadow: $shadow-bottom-level-2;
   }
 
-  > div {
-    width: 100%;
-  }
-
   &__header {
     padding: 24px 24px 0;
     width: 100%;


### PR DESCRIPTION
**CHANGELOG** :memo:

* Add word-wrap in content card profile

**SCREENSHOT** 🖼 

#### Before
<img width="1169" alt="Screen Shot 2019-12-05 at 12 56 53" src="https://user-images.githubusercontent.com/6557202/70251940-3e227900-175f-11ea-9f70-f24289119df9.png">

#### AFTER
<img width="1177" alt="Screen Shot 2019-12-05 at 12 57 22" src="https://user-images.githubusercontent.com/6557202/70251950-44185a00-175f-11ea-8db6-33b346cee63e.png">
