### PR TITLE
Temporary rollback: load fonts from the project

### DIFF
--- a/src/default/gaiden.scss
+++ b/src/default/gaiden.scss
@@ -1,5 +1,4 @@
 @import '../../node_modules/reset-css/sass/reset'; //sass-lint:disable-line clean-import-paths
-@import 'fonts/lato';
 @import 'settings/colors';
 @import 'settings/buttons';
 @import 'settings/base_font';

--- a/src/default/settings/_base_font.scss
+++ b/src/default/settings/_base_font.scss
@@ -24,6 +24,7 @@
 
 
 //sass-lint:disable no-url-domains no-url-protocols
+@import url('https://fonts.googleapis.com/css?family=Lato:400,400i,700,700i,900,900i&display=swap');
 
 $base-font: 'Lato';
 

--- a/src/yellow/gaiden.scss
+++ b/src/yellow/gaiden.scss
@@ -1,8 +1,6 @@
 @import '../../node_modules/reset-css/sass/reset';
 @import '../../node_modules/@getninjas/niten-tokens/build/web/niten-tokens';
 
-@import 'fonts/source_sans';
-
 @import 'settings/colors';
 @import 'settings/buttons';
 @import 'settings/base_font';

--- a/src/yellow/settings/_base_font.scss
+++ b/src/yellow/settings/_base_font.scss
@@ -22,6 +22,9 @@
 *
 **/
 
+//sass-lint:disable no-url-domains no-url-protocols
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,400,400i,600,600i&display=swap');
+
 $base-font: $font-family-default;
 
 $font-weight: (


### PR DESCRIPTION
We need to load the fonts from google while resolving some issues in our internal projects

**CHANGELOG** :memo:

* Load fonts from google instead of project
