### PR TITLE
Revert "temporary rollback: fonts"

### DIFF
--- a/src/default/gaiden.scss
+++ b/src/default/gaiden.scss
@@ -1,4 +1,5 @@
 @import '../../node_modules/reset-css/sass/reset'; //sass-lint:disable-line clean-import-paths
+@import 'fonts/lato';
 @import 'settings/colors';
 @import 'settings/buttons';
 @import 'settings/base_font';

--- a/src/default/settings/_base_font.scss
+++ b/src/default/settings/_base_font.scss
@@ -24,7 +24,6 @@
 
 
 //sass-lint:disable no-url-domains no-url-protocols
-@import url('https://fonts.googleapis.com/css?family=Lato:400,400i,700,700i,900,900i&display=swap');
 
 $base-font: 'Lato';
 

--- a/src/yellow/gaiden.scss
+++ b/src/yellow/gaiden.scss
@@ -1,6 +1,8 @@
 @import '../../node_modules/reset-css/sass/reset';
 @import '../../node_modules/@getninjas/niten-tokens/build/web/niten-tokens';
 
+@import 'fonts/source_sans';
+
 @import 'settings/colors';
 @import 'settings/buttons';
 @import 'settings/base_font';

--- a/src/yellow/settings/_base_font.scss
+++ b/src/yellow/settings/_base_font.scss
@@ -22,9 +22,6 @@
 *
 **/
 
-//sass-lint:disable no-url-domains no-url-protocols
-@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,400,400i,600,600i&display=swap');
-
 $base-font: $font-family-default;
 
 $font-weight: (


### PR DESCRIPTION
This reverts commit 723f3d0d141e5d142da8cbeb886908977ef2fc7d.

**CHANGELOG** :memo:

* Now we're able to load the fonts into our projects using some webpack loaders like `url-loader`:

```
{
        test: /\.(woff|woff2)$/,
        loader: 'url-loader',
        options: {
          limit: false,
          path: 'fonts/',
          name: 'static/[name].[ext]',
        },
}
```
