### PR TITLE
Fix footer spacings

### DIFF
--- a/src/yellow/components/_footer.scss
+++ b/src/yellow/components/_footer.scss
@@ -9,11 +9,6 @@
   background-color: $color-interface-shade-light;
   height: auto;
   order: 9;
-  padding: $size-spacing-xl 0 0;
-
-  @include media(normal) {
-    padding: $size-spacing-xxl 0 0;
-  }
 
   &__title {
     display: block;

--- a/src/yellow/components/footer/_index.scss
+++ b/src/yellow/components/footer/_index.scss
@@ -6,7 +6,6 @@
   background-color: $color-interface-shade-light;
   height: auto;
   order: 9;
-  padding: 0;
 
   //Used just in Storybook context
   &__container {


### PR DESCRIPTION
We don't need to use spacings into main container anymore.

**CHANGELOG** :memo:

* Remove spacings from `.footer` class
